### PR TITLE
Make job failure configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The body of the PR
 
 Base branch of the PR. Default is master.
 
+### `fail_on_error`
+
+Option to mark the job as failed in case there are errors during the action execution. Default is 'true'.
+
 ## Outputs
 
 This action has no outputs.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   destination_branch:
     description: 'Base branch of the PR. Default is master.'
     default: master
+  fail_on_error:
+    description: 'Raise an exception and mark the action as failed in case of error'
+    default: 'true'
+    required: false
 branding:
   icon: git-pull-request
   color: green

--- a/index.js
+++ b/index.js
@@ -71,5 +71,7 @@ run()
     core.error('Cannot update the pull request.');
     if (failOnError) {
       core.setFailed(e.stack || e.message);
+    } else {
+      core.error(e.stack || e.message);
     }
   });

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const run = async () => {
   const prTitle = core.getInput('pr_title');
   const prBody = core.getInput('pr_body');
   const baseBranch = core.getInput('destination_branch');
+  // Github boolean inputs are strings https://github.com/actions/runner/issues/1483
+  const failOnError = core.getInput('fail_on_error') == 'true';
   const sourceBranch = github.context.ref.replace(/^refs\/heads\//, '');
 
   const credentials = {
@@ -67,5 +69,7 @@ run()
   })
   .catch((e) => {
     core.error('Cannot update the pull request.');
-    core.setFailed(e.stack || e.message);
+    if (failOnError) {
+      core.setFailed(e.stack || e.message);
+    }
   });

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ const run = async () => {
   const prTitle = core.getInput('pr_title');
   const prBody = core.getInput('pr_body');
   const baseBranch = core.getInput('destination_branch');
-  // Github boolean inputs are strings https://github.com/actions/runner/issues/1483
-  const failOnError = core.getInput('fail_on_error') == 'true';
   const sourceBranch = github.context.ref.replace(/^refs\/heads\//, '');
 
   const credentials = {
@@ -62,6 +60,9 @@ const run = async () => {
   core.info(`Making a PATCH request to "${url}" with params "${JSON.stringify(params)}"`);
   await octokit.request(`PATCH ${url}`, params);
 };
+
+// Github boolean inputs are strings https://github.com/actions/runner/issues/1483
+const failOnError = core.getInput('fail_on_error') == 'true';
 
 run()
   .then(() => {


### PR DESCRIPTION
Resolve #8

Adds a configuration that allows us to skip marking the job as failure as we prefer to silently fail and don't have the pr description updated instead of having the whole ci suite marked as red