### PR TITLE
Update to Node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Update Pull Request Description on Push'
 description: 'GitHub Action that updates the pull request description and title'
 author: 'Yoshiya Hinosawa'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
   pre: 'deps.js'
 inputs:


### PR DESCRIPTION
Node v12 is deprecated ( https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ ), so this pull request updates it to 16.

I successfully tested this by swapping out
`uses: kt3k/update-pr-description@v1.1.0`
with
`uses: JamesChevalier/update-pr-description@402ce83264b696d0d45babc9ba783cb5e7333971`