### PR TITLE
Add support for `pull_request` events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-pull-request-description-on-push",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Update pull request description on push",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
While trying to use this action, I found out that it doesn't support `pull_request` events fired by GitHub. This PR attempts to add support for those while keeping compatibility with `push` events.

Consequently, this PR solves #4.